### PR TITLE
macOS support, boolean flag fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Currently implements:
 
     say "Human version:\n";
 
-    my %vols-human = volumes-info("human");
+    my %vols-human = volumes-info(:human);
 
     for %vols-human.sort(*.key)>>.kv -> ($location, $data) {
       say "Location: $location";

--- a/test.pl6
+++ b/test.pl6
@@ -18,7 +18,7 @@ say "----";
 
 say "Human version:\n";
 
-my %vols-human = volumes-info("human");
+my %vols-human = volumes-info(:human);
 
 for %vols-human.sort(*.key)>>.kv -> ($location, $data) {
   say "Location: $location";


### PR DESCRIPTION
### Interface changes

I've changed human flag to be Bool type.
That gives clean interface of volumes-info() and volumes-info(:human),
while string was allowing opaque calls like volumes-info("robot").
### Design changes

Methods for every OS are not meant to be called directly.
There is no point in calling linux() method on windows.
That means human readable transformation can be performed in one place
in volumes-info method (fast in-place hash values changes are used).
It removed copy-pasted human logic from each OS method.

Gather-takes in OS methods instead of returning complete hashes.
Lazy and a bit faster.
### MacOS support

Name is changed from osx to macos to follow new naming schema that Apple uses.

The only sane and bomb-proof way to parse df output was to use header position and data alignment info.
I've tested SMB / AFS / FUSE / pendrives, weird names, unrecognized filesystems, so far everything works like a charm.

Code is a bit verbose (named captures in regexps, explicit Match to gather rewrite, etc.).

**_BTW:**_ if you don't like interface and design changes feel free to reject MR and take only macOS logic from it.
